### PR TITLE
Use override specifier where needed (clang-tidy modernize-use-override)

### DIFF
--- a/cl_dll/health.h
+++ b/cl_dll/health.h
@@ -44,10 +44,10 @@ typedef struct
 class CHudHealth: public CHudBase
 {
 public:
-	virtual int Init();
-	virtual int VidInit();
-	virtual int Draw(float fTime);
-	virtual void Reset();
+    int Init() override;
+    int VidInit() override;
+    int Draw(float fTime) override;
+    void Reset() override;
 	int MsgFunc_Health(const char *pszName,  int iSize, void *pbuf);
 	int MsgFunc_Damage(const char *pszName,  int iSize, void *pbuf);
 	int m_iHealth;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -99,11 +99,11 @@ struct HUDLIST {
 class CHudAmmo: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw(float flTime);
-	void Think();
-	void Reset();
+	int Init() override;
+	int VidInit() override;
+	int Draw(float flTime) override;
+	void Think() override;
+	void Reset() override;
 	int DrawWList(float flTime);
 	int MsgFunc_CurWeapon(const char *pszName, int iSize, void *pbuf);
 	int MsgFunc_WeaponList(const char *pszName, int iSize, void *pbuf);
@@ -144,10 +144,10 @@ private:
 class CHudAmmoSecondary: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	void Reset();
-	int Draw(float flTime);
+	int Init() override;
+	int VidInit() override;
+	void Reset() override;
+	int Draw(float flTime) override;
 
 	int MsgFunc_SecAmmoVal( const char *pszName, int iSize, void *pbuf );
 	int MsgFunc_SecAmmoIcon( const char *pszName, int iSize, void *pbuf );
@@ -175,9 +175,9 @@ private:
 class CHudGeiger: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw(float flTime);
+	int Init() override;
+	int VidInit() override;
+	int Draw(float flTime) override;
 	int MsgFunc_Geiger(const char *pszName, int iSize, void *pbuf);
 	
 private:
@@ -191,9 +191,9 @@ private:
 class CHudTrain: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw(float flTime);
+	int Init() override;
+	int VidInit() override;
+	int Draw(float flTime) override;
 	int MsgFunc_Train(const char *pszName, int iSize, void *pbuf);
 
 private:
@@ -208,10 +208,10 @@ private:
 class CHudStatusBar : public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw( float flTime );
-	void Reset();
+	int Init() override;
+	int VidInit() override;
+	int Draw( float flTime ) override;
+	void Reset() override;
 	void ParseStatusString( int line_num );
 
 	int MsgFunc_StatusText( const char *pszName, int iSize, void *pbuf );
@@ -267,10 +267,10 @@ struct team_info_t
 class CHudDeathNotice : public CHudBase
 {
 public:
-	int Init();
-	void InitHUDData();
-	int VidInit();
-	int Draw( float flTime );
+	int Init() override;
+	void InitHUDData() override;
+	int VidInit() override;
+	int Draw( float flTime ) override;
 	int MsgFunc_DeathMsg( const char *pszName, int iSize, void *pbuf );
 
 private:
@@ -283,11 +283,11 @@ private:
 class CHudMenu : public CHudBase
 {
 public:
-	int Init();
-	void InitHUDData();
-	int VidInit();
-	void Reset();
-	int Draw( float flTime );
+	int Init() override;
+	void InitHUDData() override;
+	int VidInit() override;
+	void Reset() override;
+	int Draw( float flTime ) override;
 	int MsgFunc_ShowMenu( const char *pszName, int iSize, void *pbuf );
 
 	void SelectMenuItem( int menu_item );
@@ -304,10 +304,10 @@ public:
 class CHudSayText : public CHudBase
 {
 public:
-	int Init();
-	void InitHUDData();
-	int VidInit();
-	int Draw( float flTime );
+	int Init() override;
+	void InitHUDData() override;
+	int VidInit() override;
+	int Draw( float flTime ) override;
 	int MsgFunc_SayText( const char *pszName, int iSize, void *pbuf );
 	void SayTextPrint( const char *pszBuf, int iBufSize, int clientIndex = -1 );
 	void EnsureTextFitsInOneLineAndWrapIfHaveTo( int line );
@@ -325,9 +325,9 @@ private:
 class CHudBattery: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw(float flTime);
+	int Init() override;
+	int VidInit() override;
+	int Draw(float flTime) override;
 	int MsgFunc_Battery(const char *pszName,  int iSize, void *pbuf );
 	
 private:
@@ -348,10 +348,10 @@ private:
 class CHudFlashlight: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw(float flTime);
-	void Reset();
+	int Init() override;
+	int VidInit() override;
+	int Draw(float flTime) override;
+	void Reset() override;
 	int MsgFunc_Flashlight(const char *pszName,  int iSize, void *pbuf );
 	int MsgFunc_FlashBat(const char *pszName,  int iSize, void *pbuf );
 	
@@ -397,7 +397,7 @@ struct message_parms_t
 class CHudTextMessage: public CHudBase
 {
 public:
-	int Init();
+	int Init() override;
 	static char *LocaliseTextString( const char *msg, char *dst_buffer, int buffer_size );
 	static char *BufferedLocaliseTextString( const char *msg );
 	const char *LookupString( const char *msg_name, int *msg_dest = NULL );
@@ -411,9 +411,9 @@ public:
 class CHudMessage: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw(float flTime);
+	int Init() override;
+	int VidInit() override;
+	int Draw(float flTime) override;
 	int MsgFunc_HudText(const char *pszName, int iSize, void *pbuf);
 	int MsgFunc_HudTextPro(const char *pszName, int iSize, void *pbuf);
 	int MsgFunc_GameTitle(const char *pszName, int iSize, void *pbuf);
@@ -427,7 +427,7 @@ public:
 	void MessageDrawScan( client_textmessage_t *pMessage, float time );
 	void MessageScanStart();
 	void MessageScanNextChar();
-	void Reset();
+	void Reset() override;
 
 private:
 	client_textmessage_t		*m_pMessages[maxHUDMessages];
@@ -448,10 +448,10 @@ private:
 class CHudStatusIcons: public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	void Reset();
-	int Draw(float flTime);
+	int Init() override;
+	int VidInit() override;
+	void Reset() override;
+	int Draw(float flTime) override;
 	int MsgFunc_StatusIcon(const char *pszName, int iSize, void *pbuf);
 
 	enum { 
@@ -485,13 +485,13 @@ private:
 class CHudBenchmark : public CHudBase
 {
 public:
-	int Init();
-	int VidInit();
-	int Draw( float flTime );
+	int Init() override;
+	int VidInit() override;
+	int Draw( float flTime ) override;
 
 	void SetScore( float score );
 
-	void Think();
+	void Think() override;
 
 	void StartNextSection( int section );
 

--- a/cl_dll/hud_spectator.h
+++ b/cl_dll/hud_spectator.h
@@ -68,10 +68,10 @@ typedef struct cameraWayPoint_s
 class CHudSpectator : public CHudBase
 {
 public:
-	void Reset();
+	void Reset() override;
 	int  ToggleInset(bool allowOff);
 	void CheckSettings();
-	void InitHUDData();
+	void InitHUDData() override;
 	bool AddOverviewEntityToList( HSPRITE sprite, cl_entity_t * ent, double killTime);
 	void DeathMessage(int victim);
 	bool AddOverviewEntity( int type, struct cl_entity_s *ent, const char *modelname );
@@ -90,10 +90,10 @@ public:
 	void FindPlayer(const char *name);
 	void DirectorMessage( int iSize, void *pbuf );
 	void SetSpectatorStartPosition();
-	int Init();
-	int VidInit();
+	int Init() override;
+	int VidInit() override;
 
-	int Draw(float flTime);
+	int Draw(float flTime) override;
 
 	void	AddWaypoint( float time, Vector pos, Vector angle, float fov, int flags );
 	void	SetCameraView(Vector pos, Vector angle, float fov);

--- a/cl_dll/vgui_ScorePanel.h
+++ b/cl_dll/vgui_ScorePanel.h
@@ -55,8 +55,8 @@ public:
 		return _image[image];
 	}
 
-	void getSize(int &wide, int &tall)
-	{
+	void getSize(int &wide, int &tall) override
+    {
 		int w1, w2, t1, t2;
 		_image[0]->getTextSize(w1, t1);
 		_image[1]->getTextSize(w2, t2);
@@ -66,14 +66,14 @@ public:
 		setSize(wide, tall);
 	}
 
-	void doPaint(Panel *panel)
-	{
+	void doPaint(Panel *panel) override
+    {
 		_image[0]->doPaint(panel);
 		_image[1]->doPaint(panel);
 	}
 
-	void setPos(int x, int y)
-	{
+	void setPos(int x, int y) override
+    {
 		_image[0]->setPos(x, y);
 		
 		int swide, stall;
@@ -84,8 +84,8 @@ public:
 		_image[1]->setPos(x + wide, y + (stall * 0.9) - tall);
 	}
 
-	void setColor(Color color)
-	{
+	void setColor(Color color) override
+    {
 		_image[0]->setColor(color);
 	}
 
@@ -130,8 +130,8 @@ public:
 		_useFgColorAsImageColor = state;
 	}
 
-	virtual void setText(int textBufferLen, const char* text)
-	{
+    void setText(int textBufferLen, const char* text) override
+    {
 		_dualImage->GetImage(0)->setText(text);
 
 		// calculate the text size
@@ -167,13 +167,13 @@ public:
 		_dualImage->GetImage(1)->setText(text);
 	}
 
-	void getTextSize(int &wide, int &tall)
-	{
+	void getTextSize(int &wide, int &tall) override
+    {
 		_dualImage->getSize(wide, tall);
 	}
 
-	void setFgColor(int r,int g,int b,int a)
-	{
+	void setFgColor(int r,int g,int b,int a) override
+    {
 		Label::setFgColor(r,g,b,a);
 		Color color(r,g,b,a);
 		_dualImage->setColor(color);
@@ -181,8 +181,8 @@ public:
 		repaint();
 	}
 
-	void setFgColor(Scheme::SchemeColor sc)
-	{
+	void setFgColor(Scheme::SchemeColor sc) override
+    {
 		int r, g, b, a;
 		Label::setFgColor(sc);
 		Label::getFgColor( r, g, b, a );
@@ -191,8 +191,8 @@ public:
 		setFgColor( r, g, b, a );
 	}
 
-	void setFont(Font *font)
-	{
+	void setFont(Font *font) override
+    {
 		_dualImage->GetImage(0)->setFont(font);
 	}
 
@@ -208,8 +208,8 @@ public:
 		_offset[1] = y;
 	}
 
-	void paint();
-	void paintBackground();
+	void paint() override;
+	void paintBackground() override;
 	void calcAlignment(int iwide, int itall, int &x, int &y);
 
 private:
@@ -235,7 +235,7 @@ private:
 	class HitTestPanel : public Panel
 	{
 	public:
-		virtual void	internalMousePressed(MouseCode code);
+        void	internalMousePressed(MouseCode code) override;
 	};
 
 
@@ -301,8 +301,8 @@ public:
 // InputSignal overrides.
 public:
 
-	virtual void mousePressed(MouseCode code, Panel* panel);
-	virtual void cursorMoved(int x, int y, Panel *panel);
+    void mousePressed(MouseCode code, Panel* panel) override;
+    void cursorMoved(int x, int y, Panel *panel) override;
 
 	friend class CLabelHeader;
 };

--- a/cl_dll/vgui_SpectatorPanel.h
+++ b/cl_dll/vgui_SpectatorPanel.h
@@ -102,8 +102,8 @@ public:
 		m_cmd = cmd;
 	}
 
-	virtual void actionPerformed( Panel * panel )
-	{
+    void actionPerformed( Panel * panel ) override
+    {
 		m_pFather->ActionSignal(m_cmd);
 	}
 };

--- a/dlls/basemonster.h
+++ b/dlls/basemonster.h
@@ -313,7 +313,7 @@ public:
 
 	void RadiusDamage(entvars_t *pevInflictor, entvars_t *pevAttacker, float flDamage, int iClassIgnore, int bitsDamageType );
 	void RadiusDamage(Vector vecSrc, entvars_t *pevInflictor, entvars_t *pevAttacker, float flDamage, int iClassIgnore, int bitsDamageType );
-	virtual int		IsMoving() { return m_movementGoal != MOVEGOAL_NONE; }
+        int		IsMoving() override { return m_movementGoal != MOVEGOAL_NONE; }
 
 	void RouteClear();
 	void RouteNew();

--- a/dlls/func_break.h
+++ b/dlls/func_break.h
@@ -39,7 +39,7 @@ public:
 	BOOL IsBreakable();
 	BOOL SparkWhenHit();
 
-	int	 DamageDecal( int bitsDamageType );
+	int	 DamageDecal( int bitsDamageType ) override;
 
 	void EXPORT		Die();
 	int		ObjectCaps() override { return (CBaseEntity :: ObjectCaps() & ~FCAP_ACROSS_TRANSITION); }

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -294,7 +294,7 @@ public:
 	void BarnacleVictimReleased () override;
 	static int GetAmmoIndex(const char *psz);
 	int AmmoInventory( int iAmmoIndex );
-	int Illumination();
+	int Illumination() override;
 
 	void ResetAutoaim();
 	Vector GetAutoaimVector( float flDelta  );

--- a/dlls/scripted.h
+++ b/dlls/scripted.h
@@ -75,7 +75,7 @@ public:
 	virtual void FixScriptMonsterSchedule( CBaseMonster *pMonster );
 	BOOL	CanInterrupt();
 	void	AllowInterrupt( BOOL fAllow );
-	int		IgnoreConditions();
+	int		IgnoreConditions() override;
 
 	int	m_iszIdle;		// string index for idle animation
 	int	m_iszPlay;		// string index for scripted animation

--- a/dlls/talkmonster.h
+++ b/dlls/talkmonster.h
@@ -140,7 +140,7 @@ public:
 	// For following
 	BOOL			CanFollow();
 	BOOL			IsFollowing() { return m_hTargetEnt != NULL && m_hTargetEnt->IsPlayer(); }
-	void			StopFollowing( BOOL clearSchedule );
+	void			StopFollowing( BOOL clearSchedule ) override;
 	void			StartFollowing( CBaseEntity *pLeader );
 	virtual void	DeclineFollowing() {}
 	void			LimitFollowers( CBaseEntity *pPlayer, int maxFollowers );

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -48,7 +48,7 @@ public:
 	void EXPORT TumbleThink();
 
 	virtual void BounceSound();
-	virtual int	BloodColor() { return DONT_BLEED; }
+    int	BloodColor() override { return DONT_BLEED; }
 	void Killed( entvars_t *pevAttacker, int iGib ) override;
 
 	BOOL m_fRegisteredSound;// whether or not this grenade has issued its DANGER sound to the world sound list yet.
@@ -222,10 +222,10 @@ void AddAmmoNameToAmmoRegistry(const char* szAmmoname);
 class CBasePlayerItem : public CBaseAnimating
 {
 public:
-	virtual void SetObjectCollisionBox();
+    void SetObjectCollisionBox() override;
 
-	virtual int		Save( CSave &save );
-	virtual int		Restore( CRestore &restore );
+    int		Save( CSave &save ) override;
+    int		Restore( CRestore &restore ) override;
 	
 	static	TYPEDESCRIPTION m_SaveData[];
 
@@ -236,7 +236,7 @@ public:
 	void EXPORT FallThink ();// when an item is first spawned, this think is run to determine when the object has hit the ground.
 	void EXPORT Materialize();// make a weapon visible and tangible
 	void EXPORT AttemptToMaterialize();  // the weapon desires to become visible and tangible, if the game rules allow for it
-	CBaseEntity* Respawn ();// copy a weapon
+	CBaseEntity* Respawn () override;// copy a weapon
 	void FallInit();
 	void CheckRespawn();
 	virtual int GetItemInfo(ItemInfo *p) { return 0; }	// returns 0 if struct not filled out
@@ -290,8 +290,8 @@ public:
 class CBasePlayerWeapon : public CBasePlayerItem
 {
 public:
-	virtual int		Save( CSave &save );
-	virtual int		Restore( CRestore &restore );
+    int		Save( CSave &save ) override;
+    int		Restore( CRestore &restore ) override;
 	
 	static	TYPEDESCRIPTION m_SaveData[];
 
@@ -318,7 +318,7 @@ public:
 
 	virtual void SendWeaponAnim( int iAnim, int skiplocal = 1, int body = 0 );  // skiplocal is 1 if client is predicting weapon animations
 
-	virtual BOOL CanDeploy();
+    BOOL CanDeploy() override;
 	virtual BOOL IsUseable();
 	BOOL DefaultDeploy(const char *szViewModel, const char *szWeaponModel, int iAnim, const char *szAnimExt, int skiplocal = 0, int body = 0 );
 	int DefaultReload( int iClipSize, int iAnim, float fDelay, int body = 0 );
@@ -367,11 +367,11 @@ public:
 class CBasePlayerAmmo : public CBaseEntity
 {
 public:
-	virtual void Spawn();
+    void Spawn() override;
 	void EXPORT DefaultTouch( CBaseEntity *pOther ); // default weapon touch
 	virtual BOOL AddAmmo( CBaseEntity *pOther ) { return TRUE; }
 
-	CBaseEntity* Respawn();
+	CBaseEntity* Respawn() override;
 	void EXPORT Materialize();
 };
 
@@ -495,7 +495,7 @@ public:
 	void PrimaryAttack() override;
 	void SecondaryAttack() override;
 	void GlockFire( float flSpread, float flCycleTime, BOOL fUseAutoAim );
-	BOOL Deploy();
+	BOOL Deploy() override;
 	void Reload() override;
 	void WeaponIdle() override;
 
@@ -546,8 +546,8 @@ public:
 	int m_iSwing;
 	TraceResult m_trHit;
 
-	virtual BOOL UseDecrement()
-	{ 
+    BOOL UseDecrement() override
+    { 
 #if defined( CLIENT_WEAPONS )
 		return TRUE;
 #else
@@ -746,10 +746,10 @@ private:
 
 class CLaserSpot : public CBaseEntity
 {
-	void Spawn();
-	void Precache();
+	void Spawn() override;
+	void Precache() override;
 
-	int	ObjectCaps() { return FCAP_DONT_SAVE; }
+	int	ObjectCaps() override { return FCAP_DONT_SAVE; }
 
 public:
 	void Suspend( float flSuspendTime );

--- a/game_shared/vgui_scrollbar2.h
+++ b/game_shared/vgui_scrollbar2.h
@@ -36,7 +36,7 @@ public:
 	virtual void    setRange(int min,int max);
 	virtual void    setRangeWindow(int rangeWindow);
 	virtual void    setRangeWindowEnabled(bool state);
-	virtual void    setSize(int wide,int tall);
+    void    setSize(int wide,int tall) override;
 	virtual bool    isVertical();
 	virtual bool    hasFullRange();
 	virtual void    setButton(Button *button,int index);
@@ -49,7 +49,7 @@ public:
 public: //bullshit public 
 	virtual void fireIntChangeSignal();
 protected:
-	virtual void performLayout();
+    void performLayout() override;
 protected:
 	Button* _button[2];
 	Slider2 *_slider;

--- a/game_shared/vgui_slider2.h
+++ b/game_shared/vgui_slider2.h
@@ -46,7 +46,7 @@ public:
 	virtual void getRange(int& min,int& max);
 	virtual void setRangeWindow(int rangeWindow);
 	virtual void setRangeWindowEnabled(bool state);
-	virtual void setSize(int wide,int tall);
+    void setSize(int wide,int tall) override;
 	virtual void getNobPos(int& min, int& max);
 	virtual bool hasFullRange();
 	virtual void setButtonOffset(int buttonOffset);
@@ -59,7 +59,7 @@ public: //bullshit public
 	virtual void privateMouseReleased(MouseCode code,Panel* panel);
 protected:
     virtual void fireIntChangeSignal();
-	virtual void paintBackground();
+    void paintBackground() override;
 };
 
 }

--- a/game_shared/voice_status.h
+++ b/game_shared/voice_status.h
@@ -87,7 +87,7 @@ public:
 	void	UpdateSpeakerStatus(int entindex, bool bTalking);
 
 	// returns the state of this player using the enum above
-	int GetSpeakerStatus(int iPlayer);
+	int GetSpeakerStatus(int iPlayer) override;
 
 
 		// Called when the server registers a change to who this client can hear.
@@ -116,28 +116,28 @@ public:
 
 	void			UpdateServerState(bool bForce);
 
-	virtual bool CanShowSpeakerLabels()
-	{
+    bool CanShowSpeakerLabels() override
+    {
 		return m_pHelper->CanShowSpeakerLabels();
 	}
 
-	virtual void GetPlayerTextColor(int entindex, int color[3])
-	{
+    void GetPlayerTextColor(int entindex, int color[3]) override
+    {
 		m_pHelper->GetPlayerTextColor(entindex,color);
 	}
 
-	virtual int	GetAckIconHeight()
-	{
+    int	GetAckIconHeight() override
+    {
 		return m_pHelper->GetAckIconHeight();	
 	}
 
-	bool IsTalking()
-	{
+	bool IsTalking() override
+    {
 		return m_bTalking;
 	}
 
-	bool ServerAcked()
-	{
+	bool ServerAcked() override
+    {
 		return m_bServerAcked;
 	}
 


### PR DESCRIPTION
ReSharper noticed some methods that you missed when adding the `override` keyword to method declarations. Related commits: 
- 77c312a91de8c6c9cdbe2d7881aa325a4a174de9
- 543642441fabe17cc9ce173bfb9f06659954987b