### PR TITLE
Suppress False Intellisense Errors of Shared PM Files

### DIFF
--- a/pm_shared/pm_debug.cpp
+++ b/pm_shared/pm_debug.cpp
@@ -162,8 +162,10 @@ void PM_DrawPhysEntBBox(int num, int pcolor, float life)
 	if (pe->model)
 	{
 		VectorCopy(pe->origin, org);
-
+		
+#ifndef __INTELLISENSE__
 		pmove->PM_GetModelBounds( pe->model, modelmins, modelmaxs );
+#endif
 		for (j = 0; j < 8; j++)
 		{
 			tmp[0] = (j & 1) ? modelmins[0] - gap : modelmaxs[0] + gap;

--- a/pm_shared/pm_shared.cpp
+++ b/pm_shared/pm_shared.cpp
@@ -2059,7 +2059,9 @@ void PM_LadderMove( physent_t *pLadder )
 		return;
 #endif
 
+#ifndef __INTELLISENSE__
 	pmove->PM_GetModelBounds( pLadder->model, modelmins, modelmaxs );
+#endif
 
 	VectorAdd( modelmins, modelmaxs, ladderCenter );
 	VectorScale( ladderCenter, 0.5, ladderCenter );
@@ -2185,7 +2187,11 @@ physent_t *PM_Ladder()
 	{
 		pe = &pmove->moveents[i];
 		
-		if ( pe->model && (modtype_t)pmove->PM_GetModelType( pe->model ) == mod_brush && pe->skin == CONTENTS_LADDER )
+		if ( pe->model 
+#ifndef __INTELLISENSE__
+			&& (modtype_t)pmove->PM_GetModelType( pe->model ) == mod_brush 
+#endif		
+			&& pe->skin == CONTENTS_LADDER )
 		{
 
 			hull = (hull_t *)pmove->PM_HullForBsp( pe, test );


### PR DESCRIPTION
Suppression of the false Error E0167 that is present in VS2019 Intellisense
(argument of type "model_s *" is incompatible with parameter of type "model_s *")