### PR TITLE
Remove some double semicolons

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -902,7 +902,7 @@ int CHudAmmo::Draw(float flTime)
 			// draw the | bar
 			FillRGBA(x, y, iBarWidth, gHUD.m_iFontHeight, r, g, b, a);
 
-			x += iBarWidth + AmmoWidth/2;;
+			x += iBarWidth + AmmoWidth/2;
 
 			// GL Seems to need this
 			ScaleColors(r, g, b, a );

--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -103,7 +103,7 @@ void SpectatorSpray()
 	AngleVectors(v_angles,forward,NULL,NULL);
 	VectorScale(forward, 128, forward);
 	VectorAdd(forward, v_origin, forward);
-	pmtrace_t * trace = gEngfuncs.PM_TraceLine( v_origin, forward, PM_TRACELINE_PHYSENTSONLY, 2, -1 );
+    pmtrace_t * trace = gEngfuncs.PM_TraceLine( v_origin, forward, PM_TRACELINE_PHYSENTSONLY, 2, -1 );
 	if ( trace->fraction != 1.0 )
 	{
 		sprintf(string, "drc_spray %.2f %.2f %.2f %i", 
@@ -278,9 +278,9 @@ int UTIL_FindEntityInMap(const char * name, float * origin, float * angle)
 			{	
 				gEngfuncs.Con_DPrintf("UTIL_FindEntityInMap: EOF without closing brace\n");
 				return 0;
-			};
-			
-			strcpy (keyname, token);
+			}
+
+            strcpy (keyname, token);
 
 			// another hack to fix keynames with trailing spaces
 			n = strlen(keyname);
@@ -296,9 +296,9 @@ int UTIL_FindEntityInMap(const char * name, float * origin, float * angle)
 			{	
 				gEngfuncs.Con_DPrintf("UTIL_FindEntityInMap: EOF without closing brace\n");
 				return 0;
-			};
-	
-			if (token[0] == '}')
+			}
+
+            if (token[0] == '}')
 			{
 				gEngfuncs.Con_DPrintf("UTIL_FindEntityInMap: closing brace without data");
 				return 0;
@@ -310,9 +310,9 @@ int UTIL_FindEntityInMap(const char * name, float * origin, float * angle)
 				{
 					found = 1;	// thats our entity
 				}
-			};
+			}
 
-			if( !strcmp( keyname, "angle" ) )
+            if( !strcmp( keyname, "angle" ) )
 			{
 				float y = atof( token );
 				
@@ -324,8 +324,8 @@ int UTIL_FindEntityInMap(const char * name, float * origin, float * angle)
 				else if ((int)y == -1)
 				{
 					angle[0] = -90.0f;
-					angle[1] =   0.0f;;
-				}
+					angle[1] =   0.0f;
+                }
 				else
 				{
 					angle[0] = 90.0f;
@@ -344,9 +344,8 @@ int UTIL_FindEntityInMap(const char * name, float * origin, float * angle)
 			{
 				UTIL_StringToVector(origin, token);
 
-			};
-				
-		} // while (1)
+			}
+        } // while (1)
 
 		if (found)
 			return 1;
@@ -381,12 +380,12 @@ void CHudSpectator::SetSpectatorStartPosition()
 		// jump to 0,0,0 if no better position was found
 		VectorCopy(vec3_origin, m_cameraOrigin);
 		VectorCopy(vec3_origin, m_cameraAngles);
-	}
+    }
 	
 	VectorCopy(m_cameraOrigin, vJumpOrigin);
 	VectorCopy(m_cameraAngles, vJumpAngles);
 
-	iJumpSpectator = 1;	// jump anyway
+    iJumpSpectator = 1;	// jump anyway
 }
 
 
@@ -395,7 +394,7 @@ void CHudSpectator::SetCameraView(Vector pos, Vector angle, float fov)
 	m_FOV = fov;
 	VectorCopy(pos, vJumpOrigin);
 	VectorCopy(angle, vJumpAngles);
-	gEngfuncs.SetViewAngles( vJumpAngles );
+    gEngfuncs.SetViewAngles( vJumpAngles );
 	iJumpSpectator = 1;	// jump anyway
 }
 
@@ -416,7 +415,7 @@ void CHudSpectator::AddWaypoint( float time, Vector pos, Vector angle, float fov
 
 	VectorCopy( angle, m_CamPath[ m_NumWayPoints ].angle );
 	VectorCopy( pos, m_CamPath[ m_NumWayPoints ].position );
-	m_CamPath[ m_NumWayPoints ].flags = flags;
+    m_CamPath[ m_NumWayPoints ].flags = flags;
 	m_CamPath[ m_NumWayPoints ].fov = fov;
 	m_CamPath[ m_NumWayPoints ].time = time;
 
@@ -942,13 +941,13 @@ void CHudSpectator::FindNextPlayer(bool bReverse)
 		// take save camera position 
 		VectorCopy(m_cameraOrigin, vJumpOrigin);
 		VectorCopy(m_cameraAngles, vJumpAngles);
-	}
+    }
 	else
 	{
 		// use new entity position for roaming
 		VectorCopy ( pEnt->origin, vJumpOrigin );
 		VectorCopy ( pEnt->angles, vJumpAngles );
-	}
+    }
 
 	iJumpSpectator = 1;
 	gViewPort->MsgFunc_ResetFade( NULL, 0, NULL );
@@ -1000,13 +999,13 @@ void CHudSpectator::FindPlayer(const char *name)
 		// take save camera position 
 		VectorCopy(m_cameraOrigin, vJumpOrigin);
 		VectorCopy(m_cameraAngles, vJumpAngles);
-	}
+    }
 	else
 	{
 		// use new entity position for roaming
 		VectorCopy ( pEnt->origin, vJumpOrigin );
 		VectorCopy ( pEnt->angles, vJumpAngles );
-	}
+    }
 
 	iJumpSpectator = 1;
 	gViewPort->MsgFunc_ResetFade( NULL, 0, NULL );
@@ -1586,7 +1585,7 @@ void CHudSpectator::DrawOverviewEntities()
 
 		VectorCopy(ent->origin,origin);
 
-		gEngfuncs.pTriAPI->Begin( TRI_QUADS );
+        gEngfuncs.pTriAPI->Begin( TRI_QUADS );
 
 		gEngfuncs.pTriAPI->Color4f( 1.0, 1.0, 1.0, 1.0 );
 		
@@ -1672,7 +1671,7 @@ void CHudSpectator::DrawOverviewEntities()
 			
 		VectorSubtract(offset, screen, offset );
 
-		int playerNum = ent->index - 1;
+        int playerNum = ent->index - 1;
 
 		m_vPlayerPos[playerNum][0] = screen[0];	
 		m_vPlayerPos[playerNum][1] = screen[1] + Length(offset);	
@@ -1696,7 +1695,7 @@ void CHudSpectator::DrawOverviewEntities()
 	{
 		VectorCopy( v_sim_org, origin );
 		VectorCopy( v_cl_angles, angles );
-	}
+    }
 	else
 		V_GetChasePos( g_iUser2, NULL, origin, angles );
 

--- a/cl_dll/vgui_SchemeManager.cpp
+++ b/cl_dll/vgui_SchemeManager.cpp
@@ -137,9 +137,9 @@ static byte *LoadFileByResolution( const char *filePrefix, int xRes, const char 
 			return NULL;
 
 		resNum--;
-	};
+	}
 
-	return pFile;
+    return pFile;
 }
 
 static void ParseRGBAFromString( byte colorArray[4], const char *colorVector )

--- a/dlls/effects.cpp
+++ b/dlls/effects.cpp
@@ -1480,11 +1480,11 @@ void CGibShooter :: ShootThink ()
 
 	vecShootDir = pev->movedir;
 
-	vecShootDir = vecShootDir + gpGlobals->v_right * RANDOM_FLOAT( -1, 1) * m_flVariance;;
-	vecShootDir = vecShootDir + gpGlobals->v_forward * RANDOM_FLOAT( -1, 1) * m_flVariance;;
-	vecShootDir = vecShootDir + gpGlobals->v_up * RANDOM_FLOAT( -1, 1) * m_flVariance;;
+	vecShootDir = vecShootDir + gpGlobals->v_right * RANDOM_FLOAT( -1, 1) * m_flVariance;
+    vecShootDir = vecShootDir + gpGlobals->v_forward * RANDOM_FLOAT( -1, 1) * m_flVariance;
+    vecShootDir = vecShootDir + gpGlobals->v_up * RANDOM_FLOAT( -1, 1) * m_flVariance;
 
-	vecShootDir = vecShootDir.Normalize();
+    vecShootDir = vecShootDir.Normalize();
 	CGib *pGib = CreateGib();
 	
 	if ( pGib )

--- a/dlls/islave.cpp
+++ b/dlls/islave.cpp
@@ -704,8 +704,8 @@ Schedule_t *CISlave :: GetScheduleOfType ( int Type )
 	case SCHED_FAIL:
 		if (HasConditions( bits_COND_CAN_MELEE_ATTACK1 ))
 		{
-			return CSquadMonster :: GetScheduleOfType( SCHED_MELEE_ATTACK1 ); ;
-		}
+			return CSquadMonster :: GetScheduleOfType( SCHED_MELEE_ATTACK1 );
+        }
 		break;
 	case SCHED_RANGE_ATTACK1:
 		return slSlaveAttack1;

--- a/dlls/nodes.cpp
+++ b/dlls/nodes.cpp
@@ -2445,9 +2445,9 @@ int CGraph :: FLoadGraph ( char *szMapName )
 		if (length < 0) goto ShortFile;
 		memcpy(m_pRouteInfo, pMemFile, sizeof(char)*m_nRouteInfo);
 		pMemFile += sizeof(char)*m_nRouteInfo;
-		m_fRoutingComplete = TRUE;;
+		m_fRoutingComplete = TRUE;
 
-		// malloc for the hash links
+        // malloc for the hash links
 		//
 		m_pHashLinks = (short *)calloc(sizeof(short), m_nHashLinks);
 		if (!m_pHashLinks)
@@ -2740,7 +2740,7 @@ void CGraph::HashChoosePrimes(int TableSize)
     // We divide this interval into 16 equal sized zones. We want to find
     // one prime number that best represents that zone.
     //
-    int iPrime,iZone;;
+    int iPrime,iZone;
     for (iZone = 1, iPrime = 0; iPrime < 16; iZone += Spacing)
     {
         // Search for a prime number that is less than the target zone

--- a/dlls/rpg.cpp
+++ b/dlls/rpg.cpp
@@ -544,7 +544,7 @@ void CRpg::UpdateSpot()
 		}
 
 		UTIL_MakeVectors( m_pPlayer->pev->v_angle );
-		Vector vecSrc = m_pPlayer->GetGunPosition( );;
+		Vector vecSrc = m_pPlayer->GetGunPosition( );
 		Vector vecAiming = gpGlobals->v_forward;
 
 		TraceResult tr;


### PR DESCRIPTION
Resharper picked up some double semicolons. It also picked up a lot of unnecessary semicolons at the end of macro calls, however I think it's better to leave them there, as a matter of preference. (e.g. `VectorCopy(a,b);` resolves to `{(b)[0]=(a)[0];(b)[1]=(a)[1];(b)[2]=(a)[2];};` and the final semicolon is not needed)